### PR TITLE
repo/linux: Update i3c

### DIFF
--- a/repo/linux/i3c
+++ b/repo/linux/i3c
@@ -1,2 +1,9 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/i3c/linux.git
-owner: Boris Brezillon <bbrezillon@kernel.org>
+integration_testing_branches: i3c/next
+mail_cc: linux-i3c@lists.infradead.org
+owner: Alexandre Belloni <alexandre.belloni@bootlin.com>
+subsystems:
+- i3c
+private_report_branch: .*
+mail_to: Alexandre Belloni <alexandre.belloni@bootlin.com>
+public_report_branch: i3c/*


### PR DESCRIPTION
Boris hasn't been maintaining the i3c subsystem for a while, update the configuration